### PR TITLE
Double rewards fix + Pirate missions

### DIFF
--- a/CSharp/Server/McmSession.cs
+++ b/CSharp/Server/McmSession.cs
@@ -6,52 +6,35 @@ using System.Xml.Linq;
 using Microsoft.Xna.Framework;
 using Barotrauma;
 
-namespace MultiplayerCrewManager {
-    partial class McmSession {
+namespace MultiplayerCrewManager
+{
+    partial class McmSession
+    {
         private bool AllowMissionEnd;
         public GameSession Session { get; private set; }
 
-        public McmSession(GameSession session) {
+        public McmSession(GameSession session)
+        {
             Session = session;
             AllowMissionEnd = true;
         }
 
-        public void OnCampaignModeEnd(CampaignMode self)  {
+        public void OnCampaignModeEnd(CampaignMode self)
+        {
             if (!McmMod.IsCampaign) return;
 
-            foreach (var character in Character.CharacterList.Where(c => c.TeamID == CharacterTeamType.Team1 && c.IsDead).ToArray()) {
+            foreach (var character in Character.CharacterList.Where(c => c.TeamID == CharacterTeamType.Team1 && c.IsDead).ToArray())
+            {
                 character.DespawnNow(false);
                 Entity.Spawner.AddEntityToRemoveQueue(character);
             }
             Entity.Spawner.Update();
         }
 
-        /*public void OnBeforeEndRound(GameSession self) {
-            if (!McmMod.IsCampaign) return;
-            if (Session != self) Session = self;
-
-            foreach (var mission in Session.Missions) mission.End();
-
-            var characters = Character.CharacterList.Where(c => c.TeamID == CharacterTeamType.Team1 && !c.IsDead).ToList();
-            characters.ForEach(c => c.CheckTalents(AbilityEffectType.OnRoundEnd));
-
-            if (Session.Missions.Count()) {
-                var completedCount = Session.Missions.Where(m => m.Completed).Count();
-
-                if (completedCount > 0) characters.ForEach(c => c.CheckTalents(AbilityEffectType.OnAnyMissionCompleted));
-                if (completedCount == Session.Missions.Count()) characters.ForEach(c => c.CheckTalents(AbilityEffectType.OnAllMissionsCompleted));
-            }
-
-            AllowMissionEnd = false;
-        }
-        public void OnAfterEndRound(GameSession self) {
-            if (!McmMod.IsCampaign) return;
-            if (Session != self) Session = self;
-            AllowMissionEnd = true;
-        }*/
-
         private static FieldInfo isFinished = typeof(MoneyAction).GetField("isFinished", BindingFlags.Instance | BindingFlags.NonPublic);
-        public bool? OnMoneyActionUpdate(MoneyAction self, float deltaTime) { // MoneyAction
+
+        public bool? OnMoneyActionUpdate(MoneyAction self, float deltaTime)
+        { // MoneyAction
             if (!McmMod.IsCampaign) return null;
 
             if ((isFinished.GetValue(self) as bool?).Value) return true; // override
@@ -59,8 +42,10 @@ namespace MultiplayerCrewManager {
             if (GameMain.GameSession?.GameMode is CampaignMode campaign)
             {
                 var targets = self.ParentEvent.GetTargets(self.TargetTag);
-                foreach (Entity entity in targets) {
-                    if (entity is Character character) {
+                foreach (Entity entity in targets)
+                {
+                    if (entity is Character character)
+                    {
                         character.Wallet.Give(self.Amount);
                     }
                 }
@@ -68,76 +53,6 @@ namespace MultiplayerCrewManager {
             }
 
             isFinished.SetValue(self, new object[] { true });
-            return true; // override
-        }
-
-        private static FieldInfo levelField = typeof(Mission).GetField("level", BindingFlags.Instance | BindingFlags.NonPublic);
-        public bool? OnMissionGiveReward(Mission self) { // Mission
-            if (!McmMod.IsCampaign) return null;
-
-            if (!(GameMain.GameSession.GameMode is CampaignMode campaign)) return true;
-            var level = levelField.GetValue(self) as Level;
-
-            int reward = self.GetReward(Submarine.MainSub);
-
-            float baseExperienceGain = reward * 0.09f;
-
-            float difficultyMultiplier = 1 + level.Difficulty / 100f;
-            baseExperienceGain *= difficultyMultiplier;
-
-            var crewCharacters = GameSession.GetSessionCrewCharacters(CharacterType.Both).ToList();
-
-            // use multipliers here so that we can easily add them together without introducing multiplicative XP stacking
-            var experienceGainMultiplier = new AbilityExperienceGainMultiplier(1f);
-            crewCharacters.ForEach(c => c.CheckTalents(AbilityEffectType.OnAllyGainMissionExperience, experienceGainMultiplier));
-            crewCharacters.ForEach(c => experienceGainMultiplier.Value += c.GetStatValue(StatTypes.MissionExperienceGainMultiplier));
-
-            int experienceGain = (int)(baseExperienceGain * experienceGainMultiplier.Value);
-            foreach (Character character in crewCharacters)
-            {
-                character.Info?.GiveExperience(experienceGain);//, isMissionExperience: true);
-            }
-
-            // apply money gains afterwards to prevent them from affecting XP gains
-            var missionMoneyGainMultiplier = new AbilityMissionMoneyGainMultiplier(self, 1f);
-            crewCharacters.ForEach(c => c.CheckTalents(AbilityEffectType.OnGainMissionMoney, missionMoneyGainMultiplier));
-            crewCharacters.ForEach(c => missionMoneyGainMultiplier.Value += c.GetStatValue(StatTypes.MissionMoneyGainMultiplier));
-
-            int totalReward = (int)(reward * missionMoneyGainMultiplier.Value);
-            GameAnalyticsManager.AddMoneyGainedEvent(totalReward, GameAnalyticsManager.MoneySource.MissionReward, self.Prefab.Identifier.Value);
-
-            totalReward = Mission.DistributeRewardsToCrew(GameSession.GetSessionCrewCharacters(CharacterType.Both), totalReward);
-            if (totalReward > 0)
-            {
-                campaign.Bank.Give(totalReward);
-            }
-
-            foreach (Character character in crewCharacters)
-            {
-                character.Info.MissionsCompletedSinceDeath++;
-            }
-
-            foreach (KeyValuePair<Identifier, float> reputationReward in self.ReputationRewards)
-            {
-                if (reputationReward.Key == "location")
-                {
-                    self.Locations[0].Reputation.AddReputation(reputationReward.Value);
-                    self.Locations[1].Reputation.AddReputation(reputationReward.Value);
-                }
-                else
-                {
-                    Faction faction = campaign.Factions.Find(faction1 => faction1.Prefab.Identifier == reputationReward.Key);
-                    if (faction != null) { faction.Reputation.AddReputation(reputationReward.Value); }
-                }
-            }
-
-            if (self.Prefab.DataRewards != null)
-            {
-                foreach (var (identifier, value, operation) in self.Prefab.DataRewards)
-                {
-                    SetDataAction.PerformOperation(campaign.CampaignMetadata, identifier, value, operation);
-                }
-            }
             return true; // override
         }
 
@@ -150,11 +65,12 @@ namespace MultiplayerCrewManager {
         private static MethodInfo GetDifficultyModifiedAmountMethod = typeof(PirateMission).GetMethod("GetDifficultyModifiedAmount", BindingFlags.Instance | BindingFlags.NonPublic);
         private static FieldInfo characterTypeConfigField = typeof(PirateMission).GetField("characterTypeConfig", BindingFlags.Instance | BindingFlags.NonPublic);
         private static MethodInfo GetRandomDifficultyModifiedElementMethod = typeof(PirateMission).GetMethod("GetRandomDifficultyModifiedElement", BindingFlags.Instance | BindingFlags.NonPublic);
-        private static MethodInfo CreateHumanMethod = typeof(Mission).GetMethod("CreateHuman", BindingFlags.Instance | BindingFlags.NonPublic);
+        private static MethodInfo CreateHumanMethod = typeof(Mission).GetMethod("CreateHuman", BindingFlags.Static | BindingFlags.NonPublic);
         private static MethodInfo GetHumanPrefabFromElementMethod = typeof(Mission).GetMethod("GetHumanPrefabFromElement", BindingFlags.Instance | BindingFlags.NonPublic);
         private static FieldInfo enemySubField = typeof(PirateMission).GetField("enemySub", BindingFlags.Instance | BindingFlags.NonPublic);
         private static FieldInfo patrolPositionsField = typeof(PirateMission).GetField("patrolPositions", BindingFlags.Instance | BindingFlags.NonPublic);
-        public bool? OnPirateMissionInitPirates(PirateMission self) { // PirateMission
+        public bool? OnPirateMissionInitPirates(PirateMission self)
+        { // PirateMission
             if (!McmMod.IsCampaign) return null;
             var characters = charactersField.GetValue(self) as List<Character>;
             var characterItems = characterItemsField.GetValue(self) as Dictionary<Character, List<Item>>;
@@ -166,9 +82,10 @@ namespace MultiplayerCrewManager {
                 (GetDifficultyModifiedAmountMethod.Invoke(self, new object[] { minAmount, maxAmount, levelDifficulty, rand }) as int?).Value;
             var characterTypeConfig = characterTypeConfigField.GetValue(self) as XElement;
             Func<XElement, float, float, XElement> GetRandomDifficultyModifiedElement = (XElement parentElement, float levelDifficulty, float randomnessModifier) =>
-                GetRandomDifficultyModifiedElementMethod.Invoke(self, new object[] { parentElement, levelDifficulty, randomnessModifier}) as XElement;
-            Func<HumanPrefab, List<Character>, Dictionary<Character, List<Item>>, Submarine, CharacterTeamType, ISpatialEntity, Character> CreateHuman = (HumanPrefab humanPrefab, List<Character> characters, Dictionary<Character, List<Item>> characterItems, Submarine submarine, CharacterTeamType teamType, ISpatialEntity positionToStayIn) =>
-                CreateHumanMethod.Invoke(self, new object[] { humanPrefab, characters, characterItems, submarine, teamType, positionToStayIn, Rand.RandSync.ServerAndClient, true }) as Character;
+                GetRandomDifficultyModifiedElementMethod.Invoke(self, new object[] { parentElement, levelDifficulty, randomnessModifier }) as XElement;
+            Func<HumanPrefab,List<Character>,Dictionary<Character,List<Item>>,Submarine,CharacterTeamType,ISpatialEntity,Rand.RandSync,Character> CreateHuman = (HumanPrefab humanPrefab, List<Character> characters, Dictionary<Character, List<Item>> characterItems, Submarine submarine, CharacterTeamType teamType, ISpatialEntity positionToStayIn, Rand.RandSync randSync) =>
+                CreateHumanMethod.Invoke(self, new object[] { humanPrefab, characters, characterItems, submarine, teamType, positionToStayIn, randSync, }) as Character;
+
             Func<XElement, HumanPrefab> GetHumanPrefabFromElement = (XElement element) => GetHumanPrefabFromElementMethod.Invoke(self, new object[] { element }) as HumanPrefab;
             var enemySub = enemySubField.GetValue(self) as Submarine;
             var patrolPositions = patrolPositionsField.GetValue(self) as List<Vector2>;
@@ -189,6 +106,7 @@ namespace MultiplayerCrewManager {
             Random rand = new MTRandom(ToolBox.StringToInt(levelData.Seed));
 
             bool commanderAssigned = false;
+
             foreach (XElement element in characterConfig.Elements())
             {
                 // it is possible to get more than the "max" amount of characters if the modified difficulty is high enough; this is intentional
@@ -206,7 +124,7 @@ namespace MultiplayerCrewManager {
 
                     XElement variantElement = GetRandomDifficultyModifiedElement(characterType, enemyCreationDifficulty, 25); // const value PirateMission.RandomnessModifier
 
-                    Character spawnedCharacter = CreateHuman(GetHumanPrefabFromElement(variantElement), characters, characterItems, enemySub, CharacterTeamType.None, null);
+                    Character spawnedCharacter = CreateHuman(GetHumanPrefabFromElement(variantElement), characters, characterItems, enemySub, CharacterTeamType.None, null, Rand.RandSync.ServerAndClient);
                     if (!commanderAssigned)
                     {
                         bool isCommander = variantElement.GetAttributeBool("iscommander", false);


### PR DESCRIPTION
Fixed a bug where double rewards would be applied after completing a mission.
 * I've removed the hook in its entirety because v1.0 pre-patch now handles levelable bots... We don't appear to be needing to patch this any longer

Fixed a bug when trying to initialize pirate missions due to accessibility changed in some of the base methods.

Added some pre-cursor code for an upcoming fix to the whole "Create new character doesn't create a new character"... Not sure how i'm gonna solve this yet