### PR TITLE
Version 1.1.18.1 Update

### DIFF
--- a/CSharp/RunConfig.xml
+++ b/CSharp/RunConfig.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunConfig>
+  <Server>Standard</Server>
+  <Client>Standard</Client>
+</RunConfig>

--- a/CSharp/Server/McmConfig.cs
+++ b/CSharp/Server/McmConfig.cs
@@ -1,30 +1,70 @@
 using System;
+using System.Xml.Serialization;
 using Barotrauma;
 
-namespace MultiplayerCrewManager {
-    partial class McmMod {
-        public class McmConfig {
-            public int ServerUpdateFrequency = 15;
-            public bool AllowSpawnNewClients = false;
-            public bool AllowRespawns = false;
-            public bool SecureEnabled = false;
-            public bool RespawnPenalty = true;
-            public float RespawnTime = 180;
-            public float RespawnDelay = 5;
+namespace MultiplayerCrewManager
+{
+    public class McmConfig
+    {
+        public int ServerUpdateFrequency = 15;
+        public bool AllowSpawnNewClients = false;
+        public bool AllowRespawns = false;
+        public bool SecureEnabled = false;
+        public bool RespawnPenalty = true;
+        public float RespawnTime = 180;
+        public float RespawnDelay = 5;
 
-            public McmConfig() { }
-        }
+        public McmConfig() { }
+    }
 
-        public static string GetConfigFilePath => System.IO.Path.Combine(ACsMod.GetStoreFolder<McmMod>(), "McmConfig.xml");
+    partial class McmMod
+    {
+
         public static McmConfig Config { get; private set; }
 
-        public static void LoadConfig() {
-            if (LuaCsFile.Exists(GetConfigFilePath))
-                Config = LuaCsConfig.Load<McmConfig>(GetConfigFilePath);
-            else Config = new McmConfig();
+        public static void LoadConfig()
+        {
+            var cfgFilePath = System.IO.Path.Combine(ACsMod.GetStoreFolder<McmMod>(), "McmConfig.xml");
+            try
+            {
+                var serializer = new XmlSerializer(typeof(McmConfig));
+                using (var fstream = System.IO.File.OpenRead(cfgFilePath))
+                {
+                    Config = (McmConfig)serializer.Deserialize(fstream);
+                }
+                #region Old code disabled as LuaCsConfig kept crashing when attempting to load the config file
+                //if (false == string.IsNullOrWhiteSpace(cfgFilePath) && LuaCsFile.Exists(cfgFilePath))
+                //    Config = (McmConfig)LuaCsConfig.Load<object>(cfgFilePath);
+                //else Config = new McmConfig();
+                #endregion
+            }
+            catch (System.Exception e)
+            {
+                LuaCsSetup.PrintCsMessage($"[MCM-SERVER] Loading config ERROR : [{e.Message}]");
+                Config = new McmConfig();
+            }
         }
-        public static void SaveConfig() {
-            LuaCsConfig.Save(GetConfigFilePath, Config);
+        public static void SaveConfig()
+        {
+            var cfgFilePath = System.IO.Path.Combine(ACsMod.GetStoreFolder<McmMod>(), "McmConfig.xml");
+            if (false == string.IsNullOrWhiteSpace(cfgFilePath))
+            {
+                #region Directly serialize config file using xmlserializer instead of using LuaCsConfig as it caused problems when attempting to deserialize the config file afterwards
+                //LuaCsConfig.Save(cfgFilePath, Config);
+                #endregion
+                try
+                {
+                    var serializer = new XmlSerializer(typeof(McmConfig));
+                    using (var fstream = new System.IO.StreamWriter(cfgFilePath))
+                    {
+                        serializer.Serialize(fstream, Config);
+                    }
+                }
+                catch (Exception e)
+                {
+                    LuaCsSetup.PrintCsMessage($"[MCM-SERVER] Saving config ERROR : [{e.Message}]");
+                }
+            }
         }
     }
 }

--- a/CSharp/Server/McmConfig.cs
+++ b/CSharp/Server/McmConfig.cs
@@ -15,16 +15,16 @@ namespace MultiplayerCrewManager {
             public McmConfig() { }
         }
 
-        private static readonly string configFilepath = $"{ACsMod.GetSoreFolder<McmMod>()}/McmConfig.xml";
+        public static string GetConfigFilePath => System.IO.Path.Combine(ACsMod.GetStoreFolder<McmMod>(), "McmConfig.xml");
         public static McmConfig Config { get; private set; }
 
         public static void LoadConfig() {
-            if (LuaCsFile.Exists(configFilepath))
-                Config = LuaCsConfig.Load<McmConfig>(configFilepath);
+            if (LuaCsFile.Exists(GetConfigFilePath))
+                Config = LuaCsConfig.Load<McmConfig>(GetConfigFilePath);
             else Config = new McmConfig();
         }
         public static void SaveConfig() {
-            LuaCsConfig.Save(configFilepath, Config);
+            LuaCsConfig.Save(GetConfigFilePath, Config);
         }
     }
 }

--- a/CSharp/Server/McmMod.cs
+++ b/CSharp/Server/McmMod.cs
@@ -271,7 +271,6 @@ namespace MultiplayerCrewManager
                 },
                 LuaCsHook.HookMethodType.After);
 
-            // add player exp
             GameMain.LuaCs.Hook.Patch(
                "mcm_CrewManager_InitRound",
                "Barotrauma.CrewManager",
@@ -281,6 +280,7 @@ namespace MultiplayerCrewManager
                {
                    Control.OnInitRound(instance as CrewManager);
                    Save.RestoreCharactersWallets();
+                   McmSave.ImportSaveProtection();
                    return null;
                },
                LuaCsHook.HookMethodType.After);

--- a/filelist.xml
+++ b/filelist.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<contentpackage name="Multiplayer crew manager" steamworkshopid="2775613786" corepackage="false" modversion="2.0.5" gameversion="0.21.6.0" >
+<contentpackage name="Multiplayer crew manager" steamworkshopid="2775613786" corepackage="false" modversion="2.1.0" gameversion="1.1.18.1" >
   <Item file="%ModDir%/dummyitem.xml" />
   <Other file="%ModDir%/LICENSE" />
   <Other file="%ModDir%/README.md" />


### PR DESCRIPTION
- Added RunConfig.xml that was preventing the mod from being recognized

- Fixed a fatal bug in McmConfig.cs caused by using LuaCsConfig to load/save our config file. Moved to "local" solution with using our own xmlserializer to write to the supplied/alloted cfg location

- Added support in McmSave that allows the mod to be introduced into a running campaign, the mod will import users with above 0 XP and any recognized bots; recreate them as-per default with PIPE connections; and then manually save CharacterData after import and once the "session" has properly started

- Added a null guard in RestoreWallets function that could sometimes cast a null-ref error