### PR TITLE
Fixed a bug that overwrote inventory and health data when switching map

### DIFF
--- a/filelist.xml
+++ b/filelist.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<contentpackage name="Multiplayer crew manager" steamworkshopid="2775613786" corepackage="false" modversion="2.1.0" gameversion="1.1.18.1" >
+<contentpackage name="Multiplayer crew manager" steamworkshopid="2775613786" corepackage="false" modversion="2.1.2" gameversion="1.1.18.1" >
   <Item file="%ModDir%/dummyitem.xml" />
   <Other file="%ModDir%/LICENSE" />
   <Other file="%ModDir%/README.md" />


### PR DESCRIPTION
An error in design McmSave that caused an unintended bug...

Normally we read inventory and health data from the CharacterData XML; But i had a brain fart and reversed my intended logic (that is if we are unable to read data from the file; we fall back to whatever data currently attached to the toon)