### PR TITLE
2.1.3 HOTFIX

### DIFF
--- a/CSharp/Server/McmSave.cs
+++ b/CSharp/Server/McmSave.cs
@@ -65,7 +65,7 @@ namespace MultiplayerCrewManager
                 var ExistingCharacters = CharacterData.ToList(); //Add all known CharacterCampaignData (this should only be player characters... right?)
                 if (ExistingCharacters.Any())
                 {
-                    LuaCsSetup.PrintCsMessage("[MCM-SERVER] Warning! - No saved players was detected in mcm, But one or more \"non-zero\" EXP characters was found in save - Has this mod been added to a running campaign?");
+                    LuaCsSetup.PrintCsMessage("[MCM-SERVER] Warning! - One or more characters was found in save but are unknown to MCM - Has this mod been added to a running campaign?");
                     foreach (var c in ExistingCharacters)
                     {
                         LuaCsSetup.PrintCsMessage($"[MCM-SERVER] Importing character. Name [{c.CharacterInfo.Name}] Job [{c.CharacterInfo.Job.Name}] Experience [{c.CharacterInfo.ExperiencePoints}] Level [{c.CharacterInfo.GetCurrentLevel()}]");

--- a/CSharp/Server/McmSave.cs
+++ b/CSharp/Server/McmSave.cs
@@ -69,9 +69,21 @@ namespace MultiplayerCrewManager
                     foreach (var c in ExistingCharacters)
                     {
                         LuaCsSetup.PrintCsMessage($"[MCM-SERVER] Importing character. Name [{c.CharacterInfo.Name}] Job [{c.CharacterInfo.Job.Name}] Experience [{c.CharacterInfo.ExperiencePoints}] Level [{c.CharacterInfo.GetCurrentLevel()}]");
+
+                        #region
+                        //Unsure why we need to set these fields here - but without them the resulting dummy lacks both fields... Maybe this data isn't loaded at this point?
+                        //Bots seem unaffected by this bug; maybe due in fact to them not having CharacterCampaignData before being imported?
+                        if (c.CharacterInfo.InventoryData == null)
+                            c.CharacterInfo.InventoryData = (XElement)itemData.GetValue(c);
+                        if (c.CharacterInfo.HealthData == null)
+                            c.CharacterInfo.HealthData = (XElement)healthData.GetValue(c);
+                        #endregion
+
                         CharacterCampaignData charData = null;
                         using (var dummy = CreateDummy(null, c.CharacterInfo)) charData = new CharacterCampaignData(dummy);
-
+                        
+                        LuaCsSetup.PrintCsMessage($"[MCM-SERVER] Reading inventory data [{charData.CharacterInfo.InventoryData}]");
+                        
                         CharacterData.Remove(c);
                         CharacterData.Add(charData);
                         SavedPlayers.Add(charData);

--- a/filelist.xml
+++ b/filelist.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<contentpackage name="Multiplayer crew manager" steamworkshopid="2775613786" corepackage="false" modversion="2.1.2" gameversion="1.1.18.1" >
+<contentpackage name="Multiplayer crew manager" steamworkshopid="2775613786" corepackage="false" modversion="2.1.3" gameversion="1.1.18.1" >
   <Item file="%ModDir%/dummyitem.xml" />
   <Other file="%ModDir%/LICENSE" />
   <Other file="%ModDir%/README.md" />


### PR DESCRIPTION
Fixed a bug where inventory, and health data weren't properly imported when attempting to import a campaign

Unsure as to why we need to employ the solution i´ve added (Bots seem wholly unaffected by the bug, maybe because they don't have CharacterCampaignData counterpart?); So right now its sort of a duct-tape fix

Essentially, read current data from file; And stamp it to the object we use to create our dummy object... Seems to work; but i've only done a quick test

Started a campaign (without mod) - Stole some equipment, changed map, Quit to Lobby
Enabled Mod
Started save - Got the import-event
Items were still on their respective hotbar space etc...

I think this fixes it