### PR TITLE
Fixed a bug where wallet data wasn't imported 

### DIFF
--- a/CSharp/Server/McmSave.cs
+++ b/CSharp/Server/McmSave.cs
@@ -77,12 +77,17 @@ namespace MultiplayerCrewManager
                             c.CharacterInfo.InventoryData = (XElement)itemData.GetValue(c);
                         if (c.CharacterInfo.HealthData == null)
                             c.CharacterInfo.HealthData = (XElement)healthData.GetValue(c);
+
                         #endregion
 
                         CharacterCampaignData charData = null;
                         using (var dummy = CreateDummy(null, c.CharacterInfo)) charData = new CharacterCampaignData(dummy);
+
+                        //Migrate wallet data to new character
+                        LuaCsSetup.PrintCsMessage($"[MCM-SERVER] Transferring wallet data [{c.WalletData}]");
+                        charData.WalletData = c.WalletData;
                         
-                        LuaCsSetup.PrintCsMessage($"[MCM-SERVER] Reading inventory data [{charData.CharacterInfo.InventoryData}]");
+                        
                         
                         CharacterData.Remove(c);
                         CharacterData.Add(charData);
@@ -144,12 +149,12 @@ namespace MultiplayerCrewManager
                     XElement hpData = (XElement)healthData.GetValue(p); //Attempt to read from file
                     if (inventoryData == null) //If unable to read from file; attempt to fall back on current inventory data
                     {
-                        LuaCsSetup.PrintCsMessage($"[MCM-SERVER] Unit [{p.CharacterInfo.Name}] was missing inventorydata, attmepting to default");
+                        LuaCsSetup.PrintCsMessage($"[MCM-SERVER] Unit [{p.CharacterInfo.Name}] was missing inventory-data - Defaulting to CharacterInfo.InventoryData");
                         inventoryData = charInfo.InventoryData;
                     }
                     if (hpData == null) //If unable to read from file; attempt to fall back on current health data
                     {
-                        LuaCsSetup.PrintCsMessage($"[MCM-SERVER] Unit [{p.CharacterInfo.Name}] was missing healthdata, attmepting to default");
+                        LuaCsSetup.PrintCsMessage($"[MCM-SERVER] Unit [{p.CharacterInfo.Name}] was missing health-data, Defaulting to CharacterInfo.HealthData");
                         hpData = charInfo.HealthData;
                     }
                     charInfo.InventoryData = inventoryData;

--- a/filelist.xml
+++ b/filelist.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<contentpackage name="Multiplayer crew manager" steamworkshopid="2775613786" corepackage="false" modversion="2.1.3" gameversion="1.1.18.1" >
+<contentpackage name="Multiplayer crew manager" steamworkshopid="2775613786" corepackage="false" modversion="2.1.4" gameversion="1.1.18.1" >
   <Item file="%ModDir%/dummyitem.xml" />
   <Other file="%ModDir%/LICENSE" />
   <Other file="%ModDir%/README.md" />


### PR DESCRIPTION
We (or rather I) missed a bug, because the post where it was mentioned was deleted by the user who sent it.

Essentially WalletData wasn't carried over; it was easily fixed.

Tested it out.

Made a safe with the mod disabled.
Edited the save; gave me some cash - Enabled the mod and loaded the save.
Wallet had the amount of cash i had added

re-did it without editing the save.
Money was 0.

Everything seems to be working as intended (man i'm tired)