### PR TITLE
BT v1.5.9.1 fixes

### DIFF
--- a/CSharp/Server/McmChat.cs
+++ b/CSharp/Server/McmChat.cs
@@ -31,18 +31,34 @@ namespace MultiplayerCrewManager
         private static readonly Regex rMaskReleaseId = new Regex(@"^mcm\s+release\s+\d+\s*$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         private static readonly Regex rMaskDelete = new Regex(@"^mcm\s+delete\s+\d+\s*$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
-        private static readonly Regex rMaskSpawn = new Regex(@"^mcm\s+spawn\s+\d+\s*$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-
-        private static readonly Regex rMaskClientAutospawn = new Regex(@"^mcm\s+client\s+autospawn\s+(true|false)\s*$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         private static readonly Regex rMaskConfig = new Regex(@"^mcm\s+config\s*$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-        private static readonly Regex rMaskRespawnSet = new Regex(@"^mcm\s+respawn\s+set\s+(true|false)\s*$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        #region Respawn
+        private static readonly Regex rMaskSpawn = new Regex(@"^mcm\s+spawn\s+\d+\s*$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex rMaskAutospawn = new Regex(@"^mcm\s+autospawn\s+(true|false)\s*$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex rMaskRespawnSet = new Regex(@"^mcm\s+respawn\s+(true|false)\s*$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         private static readonly Regex rMaskRespawnPenalty = new Regex(@"^mcm\s+respawn\s+penalty\s+\d+\s*$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         private static readonly Regex rMaskRespawninterval = new Regex(@"^mcm\s+respawn\s+interval\s+\d+\s*$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-        private static readonly Regex rMaskRespawnMaxTransportTime = new Regex(@"^mcm\s+respawn\s+maxtransporttime\s+\d+\s*$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-        private static readonly Regex rMaskSecureEnabled = new Regex(@"^mcm\s+secure\s+(true|false)\s*$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        #endregion
+
+        #region Reserve
         private static readonly Regex rMaskReserve = new Regex(@"^mcm\s+reserve\s*$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         private static readonly Regex rMaskReservePut = new Regex(@"^mcm\s+reserve\s+put\s+\d+\s?(force)?\s*$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         private static readonly Regex rMaskReserveGet = new Regex(@"^mcm\s+reserve\s+get\s+\d+\s*$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        #endregion
+
+        #region Shuttle
+        private static readonly Regex rMaskShuttles = new Regex(@"^mcm\s+shuttles\s*$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex rMaskUseShuttle = new Regex(@"^mcm\s+useshuttle\s+(true|false)\s*$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        private const string shuttleNameMatchGroup = "shuttlename";
+        // for the shuttle name, we tolerate any string that starts with anything except a space ([^ ]), and end with anything except a space ([^ ]). It can have space inside though! \s*
+        private static readonly Regex rMaskShuttleName = new Regex(@"^mcm\s+shuttle\s+(?<"+shuttleNameMatchGroup+@">[^ ]+\s*[^ ]+)+\s*$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex rMaskRespawnShuttleTransportTime = new Regex(@"^mcm\s+shuttletransporttime\s+\d+\s*$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        #endregion
+        private static readonly Regex rMaskSecureEnabled = new Regex(@"^mcm\s+secure\s+(true|false)\s*$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
         private static readonly Regex rMaskLoggingLevelSet = new Regex(@"^mcm\slogging\s\d$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         private static readonly Regex rMaskIntValue = new Regex(@"\s+\d+\s*$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
@@ -93,7 +109,7 @@ namespace MultiplayerCrewManager
                     (messageType, response) = ChatSpawnId(message, sender);
                 }
                     break;
-                case var _ when rMaskClientAutospawn.IsMatch(message):
+                case var _ when rMaskAutospawn.IsMatch(message):
                 {
                     // mcm client autospawn
                     (messageType, response) = ChatAutospawn(message, sender);
@@ -117,10 +133,28 @@ namespace MultiplayerCrewManager
                     (messageType, response) = ChatRespawnPenalty(message, sender);
                 }
                     break;
-                case var _ when rMaskRespawnMaxTransportTime.IsMatch(message):
+                case var _ when rMaskUseShuttle.IsMatch(message):
                 {
-                    // mcm respawn maxtransporttime <number>
-                    (messageType, response) = ChatMaxTransportTime(message, sender);
+                    // mcm useshuttle
+                    (messageType, response) = ChatUseShuttle(message, sender);
+                }
+                    break;
+                case var _ when rMaskShuttleName.IsMatch(message):
+                {
+                    // mcm shuttle <shuttlename>
+                    (messageType, response) = ChatShuttleName(message, sender);
+                }
+                    break;
+                case var _ when rMaskRespawnShuttleTransportTime.IsMatch(message):
+                {
+                    // mcm shuttletransporttime <number>
+                    (messageType, response) = ChatShuttleTransportTime(message, sender);
+                }
+                    break;
+                case var _ when rMaskShuttles.IsMatch(message):
+                {
+                    // mcm shuttles
+                    (messageType, response) = ChatShuttlesList(message, sender);
                 }
                     break;
                 case var _ when rMaskConfig.IsMatch(message):
@@ -176,6 +210,62 @@ namespace MultiplayerCrewManager
             return true;
         }
 
+        private (ChatMessageType messageType, string response) ChatShuttleName(string message, Client sender)
+        {
+            string response;
+            if (!sender.HasPermission(ClientPermissions.ConsoleCommands))
+                return SetPrivilegeError();
+
+
+
+            Group match = rMaskShuttleName.Match(message).Groups[shuttleNameMatchGroup];
+            var shuttleName = match.Value;
+
+
+            SubmarineInfo shuttle = SubmarineInfo.SavedSubmarines.FirstOrDefault(s => string.Equals(s.DisplayName.Value, shuttleName, StringComparison.InvariantCultureIgnoreCase));
+            if (shuttle == null)
+            {
+                response =
+                    $"Error: No shuttle named '{shuttleName}' in the list of available submarines. " +
+                    $"Have you delete a mod or local submarine file?\n" +
+                    $"Use 'mcm shuttles' to display list of available shuttles";
+                return (ChatMessageType.Server, response);
+            }
+
+            McmMod.Config.RespawnShuttle = shuttleName;
+
+            response = $"[MCM] now using shuttle '{McmMod.Config.RespawnShuttle}'";
+
+            return (ChatMessageType.Server, response);
+        }
+
+        private (ChatMessageType messageType, string response) ChatUseShuttle(string message, Client sender)
+        {
+            ChatMessageType messageType;
+            string response;
+            if (sender.HasPermission(ClientPermissions.ConsoleCommands))
+            {
+                messageType = ChatMessageType.Server;
+                Boolean.TryParse(rMaskBoolValue.Match(message).Value, out bool value);
+                if (value) response = $"[MCM] {nameof(McmMod.Config.UseShuttle).ToLowerInvariant()} turned ON";
+                else response = $"[MCM] {nameof(McmMod.Config.UseShuttle).ToLowerInvariant()} turned OFF";
+                McmMod.Config.UseShuttle = value;
+            }
+            else (messageType, response) = SetPrivilegeError();
+
+            return (messageType, response);
+        }
+
+        private (ChatMessageType messageType, string response) ChatShuttlesList(string message, Client sender)
+        {
+            string response = @"
+--------------------------------------------
+--------Available Subs / Shuttles -------
+--------------------------------------------" + 
+                              $"\n{McmMod.Config.AvailableShuttles()}";
+            return (ChatMessageType.ServerMessageBox, response);
+        }
+
         private (ChatMessageType messageType, string response) ChatRespawnPenalty(string message, Client sender)
         {
             ChatMessageType messageType;
@@ -185,7 +275,7 @@ namespace MultiplayerCrewManager
                 messageType = ChatMessageType.Server;
                 Int32.TryParse(rMaskIntValue.Match(message).Value, out int penalty);
                 response = $"[MCM] Respawn penalty is set to {penalty}%";
-                McmMod.Config.SkillLossPercentageOnDeath = Math.Max((float)penalty, 0);
+                McmMod.Config.RespawnPenalty = Math.Max((float)penalty, 0);
                 McmMod.SaveConfig();
             }
             else (messageType, response) = SetPrivilegeError();
@@ -298,14 +388,14 @@ namespace MultiplayerCrewManager
             var messageType = ChatMessageType.ServerMessageBox;
             var response = @"
 --------------------------------------------
--------------MCM Configuration--------------
+-------------MCM Configuration-----------
 --------------------------------------------" +
                            $"\n\n{McmMod.Config.ToString()}";
             
             return (messageType, response);
         }
 
-        private (ChatMessageType messageType, string response) ChatMaxTransportTime(string message, Client sender)
+        private (ChatMessageType messageType, string response) ChatShuttleTransportTime(string message, Client sender)
         {
             ChatMessageType messageType;
             string response;
@@ -314,7 +404,7 @@ namespace MultiplayerCrewManager
                 messageType = ChatMessageType.Server;
                 Int32.TryParse(rMaskIntValue.Match(message).Value, out int time);
                 response = $"[MCM] Respawn shuttle catch-up time is set to {time} seconds";
-                McmMod.Config.MaxTransportTime = (float)time;
+                McmMod.Config.ShuttleTransportTime = (float)time;
 
             }
             else (messageType, response) = SetPrivilegeError();
@@ -349,7 +439,7 @@ namespace MultiplayerCrewManager
                 Boolean.TryParse(rMaskBoolValue.Match(message).Value, out bool value);
                 if (value) response = "[MCM] Respawning is turned ON";
                 else response = "[MCM] Respawning is turned OFF";
-                McmMod.Config.AllowRespawn = value;
+                McmMod.Config.RespawnAllowed = value;
                 McmMod.SaveConfig();
             }
             else (messageType, response) = SetPrivilegeError();
@@ -367,7 +457,7 @@ namespace MultiplayerCrewManager
                 Boolean.TryParse(rMaskBoolValue.Match(message).Value, out bool value);
                 if (value) response = "[MCM] Automatic new client character spawn is turned ON";
                 else response = "[MCM] Automatic new client character spawn is turned OFF";
-                McmMod.Config.AllowSpawnNewClients = value;
+                McmMod.Config.AutoSpawn = value;
                 McmMod.SaveConfig();
             }
             else (messageType, response) = SetPrivilegeError();
@@ -386,7 +476,7 @@ namespace MultiplayerCrewManager
                     Int32.TryParse(rMaskIntValue.Match(message).Value, out int clientId);
 
                     messageType = ChatMessageType.Error;
-                    var client = Client.ClientList.FirstOrDefault(c => clientId == c.Character.ID);
+                    var client = Client.ClientList.FirstOrDefault(c => clientId == c.Character.ID || clientId == c.NameId);
                     if (client != null)
                     {
                         if (Mod.TryCeateClientCharacter(client))
@@ -546,7 +636,11 @@ namespace MultiplayerCrewManager
             string response = string.Empty;
             if (character != null)
                 response += Stringify(character);
-            
+            else if (client.NameId != 0)
+                response += $"Spectator / use 'mcm spawn {client.NameId}' "; 
+            else
+                response += $"Player in Lobby";
+
             response += $"| {client.SteamID} - {client.Name}";
 
             return response;
@@ -612,13 +706,18 @@ usage: mcm [function] [args]
 
 —mcm spawn <ID> - spawn client character
 —mcm delete <ID> - delete character (with inventory)
-—mcm client autospawn <true/false> - automatic spawning for new clients
+—mcm autospawn <true/false> - automatic spawning for new clients
 —mcm release <ID> - release controlled character back to AI
 
-—mcm respawn set <true/false> - turn respawning on/off
+—mcm respawn <true/false> - turn respawning on/off
 —mcm respawn penalty <number> - set respawning penalty percentage. Disabled if <=0
 —mcm respawn interval <number> - time to wait before respawning
-—mcm respawn maxtransporttime <number> - respawn shuttle time to catch up with the main sub
+
+—mcm useshuttle <true/false> - set whether to use a shuttle
+—mcm shuttle <shuttleName> - use the given shuttle for respawn
+—mcm shuttle maxtransporttime <number> - respawn shuttle time to catch up with the main sub
+—mcm shuttles - list of available shuttles
+
 
 -mcm reserve - show characters stocked in reserve
 -mcm reserve put <ID> - put character in reserve

--- a/CSharp/Server/McmConfig.cs
+++ b/CSharp/Server/McmConfig.cs
@@ -21,7 +21,7 @@ namespace MultiplayerCrewManager
         public McmLoggingLevel LoggingLevel = McmLoggingLevel.Info;
 
         public int ServerUpdateFrequency = 15;
-        public bool AutoSpawn = false;
+        public bool AutoSpawn = true;
         public bool SecureEnabled = false;
         //public float RespawnDelay = 5;
 
@@ -63,10 +63,10 @@ namespace MultiplayerCrewManager
             set => respawnInterval.SetValue(GameMain.Server.ServerSettings, value);
         }
 
-        public bool RespawnAllowed
+        public RespawnMode RespawnMode
         {
-            get => GameMain.Server.ServerSettings.AllowRespawn;
-            set => GameMain.Server.ServerSettings.AllowRespawn = value;
+            get => GameMain.Server.ServerSettings.RespawnMode;
+            set => GameMain.Server.ServerSettings.RespawnMode = value;
         }
 
         public float RespawnPenalty
@@ -133,13 +133,13 @@ namespace MultiplayerCrewManager
         {
             return
                 $"New Clients {nameof(AutoSpawn)}: {AutoSpawn}\n" +
-                $"{nameof(RespawnAllowed)}: {RespawnAllowed}\n" +
+                $"{nameof(RespawnMode)}: {RespawnMode}\n" +
                 $"{nameof(RespawnInterval)}: {RespawnInterval}s\n" +
                 $"{nameof(RespawnPenalty)}: {RespawnPenalty}\n" +
                 "---------------------------\n" +
                 $"{nameof(UseShuttle)}: {UseShuttle}\n" +
                 $"{nameof(RespawnShuttle)}: {RespawnShuttle}\n" +
-                $"Shuttle {nameof(ShuttleTransportTime)}: {ShuttleTransportTime}s\n" +
+                $"{nameof(ShuttleTransportTime)}: {ShuttleTransportTime}s\n" +
                 "---------------------------\n" +
                 $"{nameof(SecureEnabled)}: {SecureEnabled},\n" +
                 $"{nameof(LoggingLevel)}: {(int)LoggingLevel} - {LoggingLevel}\n" +

--- a/CSharp/Server/McmConfig.cs
+++ b/CSharp/Server/McmConfig.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Linq;
 using System.Reflection;
+using System.Text;
 using System.Xml.Serialization;
 using Barotrauma;
 using Barotrauma.Networking;
@@ -19,13 +21,15 @@ namespace MultiplayerCrewManager
         public McmLoggingLevel LoggingLevel = McmLoggingLevel.Info;
 
         public int ServerUpdateFrequency = 15;
-        public bool AllowSpawnNewClients = false;
+        public bool AutoSpawn = false;
         public bool SecureEnabled = false;
         //public float RespawnDelay = 5;
 
         private readonly PropertyInfo maxTransportTime;
         private readonly PropertyInfo respawnInterval;
         private readonly PropertyInfo skillLossPercentageOnDeath;
+        private readonly PropertyInfo useRespawnShuttle;
+
 
         public McmConfig()
         {
@@ -41,9 +45,13 @@ namespace MultiplayerCrewManager
             if (skillLossPercentageOnDeath is null)
                 throw new ApplicationException($"{typeof(McmConfig)} constructor. Could not perform GetProperty on ServerSettings.RespawnInterval");
 
+            useRespawnShuttle = typeof(ServerSettings).GetProperty("UseRespawnShuttle");
+            if (useRespawnShuttle is null)
+                throw new ApplicationException($"{typeof(McmConfig)} constructor. Could not perform GetProperty on ServerSettings.UseRespawnShuttle");
+
         }
 
-        public float MaxTransportTime
+        public float ShuttleTransportTime
         {
             get => GameMain.Server.ServerSettings.MaxTransportTime;
             set => maxTransportTime.SetValue(GameMain.Server.ServerSettings, value);
@@ -55,29 +63,88 @@ namespace MultiplayerCrewManager
             set => respawnInterval.SetValue(GameMain.Server.ServerSettings, value);
         }
 
-        public bool AllowRespawn
+        public bool RespawnAllowed
         {
             get => GameMain.Server.ServerSettings.AllowRespawn;
             set => GameMain.Server.ServerSettings.AllowRespawn = value;
         }
 
-        public float SkillLossPercentageOnDeath
+        public float RespawnPenalty
         {
             get => GameMain.Server.ServerSettings.SkillLossPercentageOnDeath;
             set => skillLossPercentageOnDeath.SetValue(GameMain.Server.ServerSettings, value);
         }
 
+        public bool UseShuttle
+        {
+            get => GameMain.Server.ServerSettings.UseRespawnShuttle;
+            set => useRespawnShuttle.SetValue(GameMain.Server.ServerSettings, value);
+        }
+
+        public string AvailableShuttles()
+        {
+            return SubmarineInfo.SavedSubmarines.Where(s => s.IsPlayer && s.HasTag(SubmarineTag.Shuttle)).Aggregate(
+                    new StringBuilder(),
+                    (current, next) => current.Append(current.Length == 0 ? "" : " | ").Append(next.DisplayName.Value))
+                .ToString();
+        }
+
+        /// <summary>
+        /// The Display name of the shuttle.
+        /// Little trick = we manipulate the shuttle using the display name, but in the settings we convert it to the actual system shuttle name
+        /// </summary>
+        public string RespawnShuttle
+        {
+            get
+            {
+                if (GameMain.Server.ServerSettings.SelectedShuttle.IsNullOrEmpty())
+                    return "None Selected";
+
+                SubmarineInfo shuttle = SubmarineInfo.SavedSubmarines.FirstOrDefault(s => 
+                    IsPlayerShuttle(s) 
+                    && s.Name == GameMain.Server.ServerSettings.SelectedShuttle);
+
+                if (shuttle == null)
+                    return
+                        $"Error, couldn't find the designated shuttle '{GameMain.Server.ServerSettings.SelectedShuttle}' in the list of available submarines. " +
+                        $"Have you deleted the mod or local submarine file?\n" +
+                        $"Check the MCM commands list to display the list of available shuttles.";
+
+                return shuttle.DisplayName.Value;
+            }
+            set
+            {
+                // We use the friendly DisplayName when choosing a shuttle
+                SubmarineInfo shuttle = SubmarineInfo.SavedSubmarines.FirstOrDefault(s => 
+                    IsPlayerShuttle(s) 
+                    && string.Equals(s.DisplayName.Value, value, StringComparison.InvariantCultureIgnoreCase));
+
+                GameMain.Server.ServerSettings.SelectedShuttle = shuttle != null 
+                    ? shuttle.Name 
+                    : "";
+            }
+        }
+        private bool IsPlayerShuttle(SubmarineInfo submarineInfo)
+        {
+            return submarineInfo.IsPlayer && submarineInfo.HasTag(SubmarineTag.Shuttle);
+        }
+
         public override string ToString()
         {
             return
-                $"{nameof(AllowRespawn)}: {AllowRespawn}\n" +
-                $"{nameof(AllowSpawnNewClients)}: {AllowSpawnNewClients}\n" +
-                $"{nameof(LoggingLevel)}: {(int)LoggingLevel} - {LoggingLevel}\n" +
-                $"{nameof(MaxTransportTime)}: {MaxTransportTime}s\n" +
+                $"New Clients {nameof(AutoSpawn)}: {AutoSpawn}\n" +
+                $"{nameof(RespawnAllowed)}: {RespawnAllowed}\n" +
                 $"{nameof(RespawnInterval)}: {RespawnInterval}s\n" +
+                $"{nameof(RespawnPenalty)}: {RespawnPenalty}\n" +
+                "---------------------------\n" +
+                $"{nameof(UseShuttle)}: {UseShuttle}\n" +
+                $"{nameof(RespawnShuttle)}: {RespawnShuttle}\n" +
+                $"Shuttle {nameof(ShuttleTransportTime)}: {ShuttleTransportTime}s\n" +
+                "---------------------------\n" +
                 $"{nameof(SecureEnabled)}: {SecureEnabled},\n" +
-                $"{nameof(ServerUpdateFrequency)}: {ServerUpdateFrequency}s\n" +
-                $"{nameof(SkillLossPercentageOnDeath)}: {SkillLossPercentageOnDeath}%";
+                $"{nameof(LoggingLevel)}: {(int)LoggingLevel} - {LoggingLevel}\n" +
+                $"{nameof(ServerUpdateFrequency)}: {ServerUpdateFrequency}s";
+
         }
     }
 

--- a/CSharp/Server/McmControl.cs
+++ b/CSharp/Server/McmControl.cs
@@ -77,7 +77,7 @@ namespace MultiplayerCrewManager
         public void ReduceCharacterSkills(CharacterInfo charInfo)
         {
             if (charInfo.Job == null) return;
-            var skillLoss = McmMod.Config.SkillLossPercentageOnDeath;
+            var skillLoss = McmMod.Config.RespawnPenalty;
             var convertedToScalar = 1f - (skillLoss / 100);
             foreach (var skill in charInfo.Job.GetSkills())
             {

--- a/CSharp/Server/McmControl.cs
+++ b/CSharp/Server/McmControl.cs
@@ -219,7 +219,7 @@ namespace MultiplayerCrewManager
             if (!McmMod.IsCampaign) return null;
             if (RespawnManager != self) RespawnManager = self;
 
-            if (GameMain.Server.ServerSettings.AllowRespawn)
+            if (McmMod.Config.RespawnMode == RespawnMode.MidRound)
             {
                 counter--;
                 if (counter <= 0)

--- a/CSharp/Server/McmMod.cs
+++ b/CSharp/Server/McmMod.cs
@@ -13,12 +13,11 @@ namespace MultiplayerCrewManager
 {
     partial class McmMod
     {
-        private GameServer server = GameMain.Server;
         private FieldInfo endRoundTimerFiled = typeof(GameServer).GetField("endRoundTimer", BindingFlags.Instance | BindingFlags.NonPublic);
         private float endRoundTimer
         {
-            get => (endRoundTimerFiled.GetValue(server) as float?).Value;
-            set => endRoundTimerFiled.SetValue(server, value);
+            get => (endRoundTimerFiled.GetValue(GameMain.Server) as float?).Value;
+            set => endRoundTimerFiled.SetValue(GameMain.Server, value);
         }
         protected Action UpdateAction = null;
 
@@ -181,9 +180,9 @@ namespace MultiplayerCrewManager
                     }
 
 
-                    if ((instance as GameServer) != server)
+                    if ((instance as GameServer) != GameMain.Server)
                     {
-                        server = instance as GameServer;
+                        GameMain.Server = instance as GameServer;
                     }
 
                     if (endRoundTimer > 0.0f)
@@ -348,7 +347,7 @@ namespace MultiplayerCrewManager
                     client.SpectateOnly = true;
                     McmUtils.Info($"New client - {client.CharacterID} | '{client.Name}'");
                     // if spawning is enabled then check if spawn is needed
-                    if (McmMod.Config.AllowSpawnNewClients && client.InGame && client.Character == null)
+                    if (McmMod.Config.AutoSpawn && client.InGame && client.Character == null)
                     {
                         var character = Character.CharacterList.FirstOrDefault(c => c.TeamID == CharacterTeamType.Team1 && c.Name == client.Name);
                         if (character != null && !Manager.IsCurrentlyControlled(character)) Manager.Set(client, character);

--- a/CSharp/Server/McmMod.cs
+++ b/CSharp/Server/McmMod.cs
@@ -13,12 +13,14 @@ namespace MultiplayerCrewManager
 {
     partial class McmMod
     {
-        private FieldInfo endRoundTimerFiled = typeof(GameServer).GetField("endRoundTimer", BindingFlags.Instance | BindingFlags.NonPublic);
-        private float endRoundTimer
+        private PropertyInfo endRoundTimerProperty = typeof(GameServer).GetProperty("EndRoundTimer");
+        private float EndRoundTimer
         {
-            get => (endRoundTimerFiled.GetValue(GameMain.Server) as float?).Value;
-            set => endRoundTimerFiled.SetValue(GameMain.Server, value);
+            get => GameMain.Server.EndRoundTimer;
+            
+            set => endRoundTimerProperty.SetValue(GameMain.Server, value);
         }
+
         protected Action UpdateAction = null;
 
         public McmClientManager Manager { get; private set; }
@@ -174,7 +176,7 @@ namespace MultiplayerCrewManager
                         return null;
                     }
 
-                    if (false == GameMain.Server.ServerSettings.AllowRespawn)
+                    if (McmMod.Config.RespawnMode!= RespawnMode.MidRound)
                     {
                         return null;
                     }
@@ -185,19 +187,19 @@ namespace MultiplayerCrewManager
                         GameMain.Server = instance as GameServer;
                     }
 
-                    if (endRoundTimer > 0.0f)
+                    if (GameMain.Server.EndRoundTimer > 0.0f)
                     {
-                        McmUtils.Trace($"Endround Timer [{endRoundTimer}]");
+                        McmUtils.Trace($"Endround Timer [{EndRoundTimer}]");
 
                         var alliedChars = Character.CharacterList.Where(c => c.TeamID == CharacterTeamType.Team1);
                         if (alliedChars.Any(c => false == c.IsDead || false == c.IsIncapacitated))
                         {
-                            endRoundTimer = -5.0f;
-                            McmUtils.Trace($"There are still alive characters in team, setting new end round timer [{endRoundTimer}]");
+                            EndRoundTimer = -5.0f;
+                            McmUtils.Trace($"There are still alive characters in team, setting new end round timer [{EndRoundTimer}]");
                         }
-                        else if (endRoundTimer < 0.0f)
+                        else if (EndRoundTimer < 0.0f)
                         {
-                            endRoundTimer = 0.0f;
+                            EndRoundTimer = 0.0f;
                             McmUtils.Trace("Clamping timer to 0");
                         }
                     }

--- a/CSharp/Server/McmReserve.cs
+++ b/CSharp/Server/McmReserve.cs
@@ -6,7 +6,6 @@ using System.Xml.Linq;
 using Barotrauma;
 using Barotrauma.IO;
 using Barotrauma.Networking;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace MultiplayerCrewManager
 {

--- a/CSharp/Server/McmSave.cs
+++ b/CSharp/Server/McmSave.cs
@@ -278,14 +278,14 @@ namespace MultiplayerCrewManager
                         CharacterData.Add(charData);
                         str += $"\n    {character.ID} | {character.Name} - OK";
                     }
-                    else if (false == GameMain.Server.ServerSettings.AllowRespawn)
+                    else if (McmMod.Config.RespawnMode != RespawnMode.MidRound)
                     {
                         str += $"\n    {character.ID} | {character.Name} - Dead";
                     }
                 }
             }
             // add dead
-            if (GameMain.Server.ServerSettings.AllowRespawn)
+            if (McmMod.Config.RespawnMode == RespawnMode.MidRound)
             {
                 foreach (var charInfo in Control.Awaiting)
                 {

--- a/CSharp/Server/McmSession.cs
+++ b/CSharp/Server/McmSession.cs
@@ -11,11 +11,9 @@ namespace MultiplayerCrewManager
     partial class McmSession
     {
         private bool AllowMissionEnd;
-        public GameSession Session { get; private set; }
 
         public McmSession(GameSession session)
         {
-            Session = session;
             AllowMissionEnd = true;
         }
 


### PR DESCRIPTION
Fixes the mod for version v1.5.9.1.
**Bugs known: **
- - Autospawn enabled by default until I find how to fix the manual addition of joining players
- - Potential other issues to be tested further

**Adding many features:**
Fixed issue -respawn shuttle not appearing.
New command 'mcm shuttle <shuttlename>' to choose shuttle
New command 'mcm shuttles' to list available shuttles
New command 'mcm useshuttle <true/false>' to use the shuttle or not
Changed command 'mcm respawn set <true/false>' to 'mcm respawnmode <true/false>'
Changed command 'mcm maxtransporttime <number>' to  'mcm respawnmode <0/1/2> - turn respawn mode to (0 - MidRound, 1 - BetweenRounds, 2 - Permadeath. Effective at next round.'